### PR TITLE
Fix invalid spec field in dashboard ConfigMap template

### DIFF
--- a/helm_charts/ibm-workload-automation-prod/templates/dashboard-generic.yaml
+++ b/helm_charts/ibm-workload-automation-prod/templates/dashboard-generic.yaml
@@ -14,7 +14,6 @@ metadata:
   labels:
      grafana_dashboard: "1"
 {{ include "wa.server.labels" . | indent 5 }}
-spec:
 data:
   k8s-{{ .Release.Name }}-dashboard.json: |-
 {{ tpl (.Files.Get "dashboards/WA_Performance_Metrics.json") . | indent 5 }}


### PR DESCRIPTION
## Summary
This PR fixes a Helm rendering issue in the dashboard ConfigMap template.

## Problem
`wa-grafana-common-dashboard` was rendered with a top-level `spec` field. For `v1/ConfigMap`, `spec` is not part of the schema, so installs/upgrades could fail with:

`failed to create typed patch object (.../wa-grafana-common-dashboard; /v1, Kind=ConfigMap): .spec: field not declared in schema`

## Fix
- Removed the invalid top-level `spec:` key from:
  - `helm_charts/ibm-workload-automation-prod/templates/dashboard-generic.yaml`

## Scope
- Single-file change
- No behavior changes beyond producing a schema-valid ConfigMap manifest

## Validation
- Confirmed template renders `wa-grafana-common-dashboard` without top-level `spec`
- Change is isolated to the dashboard ConfigMap template
