### PR TITLE
Add destinationCACertificate support for OpenShift reencrypt routes

### DIFF
--- a/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
@@ -33,7 +33,7 @@ spec:
     {{- if $secret }}
     {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 6 }}
     {{- else }}
     {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
@@ -35,10 +35,10 @@ spec:
     destinationCACertificate: |
 {{ index $secret.data "ca.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
     {{- end }}
     {{- else }}
-    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
     {{- end }}
     {{- end }}
   wildcardPolicy: None

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
@@ -28,6 +28,19 @@ spec:
   tls:
     termination: {{ .Values.global.routeType | default "passthrough" }}
     insecureEdgeTerminationPolicy: None
+    {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
+    {{- if $secret }}
+    {{- if index $secret.data "ca.crt" }}
+    destinationCACertificate: |
+{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+    {{- else }}
+    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- end }}
+    {{- else }}
+    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- end }}
+    {{- end }}
   wildcardPolicy: None
 status:
   ingress:

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-aida-prod/charts/aida-nginx/templates/route.yaml
@@ -31,11 +31,11 @@ spec:
     {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
     {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
     {{- if $secret }}
-    {{- if index $secret.data "ca.crt" }}
+    {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
     {{- else }}
     {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
@@ -36,10 +36,10 @@ spec:
     destinationCACertificate: |
 {{ index $secret.data "ca.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
     {{- end }}
     {{- else }}
-    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
     {{- end }}
     {{- end }}
   wildcardPolicy: None

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
@@ -34,7 +34,7 @@ spec:
     {{- if $secret }}
     {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 6 }}
     {{- else }}
     {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
@@ -29,6 +29,19 @@ spec:
   tls:
     termination: {{ .Values.global.routeType | default "passthrough" }}
     insecureEdgeTerminationPolicy: None
+    {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
+    {{- if $secret }}
+    {{- if index $secret.data "ca.crt" }}
+    destinationCACertificate: |
+{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+    {{- else }}
+    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- end }}
+    {{- else }}
+    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- end }}
+    {{- end }}
   wildcardPolicy: None
 status:
   ingress:

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-console-prod/templates/dwc-route.yaml
@@ -32,11 +32,11 @@ spec:
     {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
     {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
     {{- if $secret }}
-    {{- if index $secret.data "ca.crt" }}
+    {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
     {{- else }}
     {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
@@ -34,10 +34,10 @@ spec:
     destinationCACertificate: |
 {{ index $secret.data "ca.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
     {{- end }}
     {{- else }}
-    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
     {{- end }}
     {{- end }}
   wildcardPolicy: None

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
@@ -27,6 +27,19 @@ spec:
   tls:
     termination: {{ .Values.global.routeType | default "passthrough" }}
     insecureEdgeTerminationPolicy: None
+    {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
+    {{- if $secret }}
+    {{- if index $secret.data "ca.crt" }}
+    destinationCACertificate: |
+{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+    {{- else }}
+    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- end }}
+    {{- else }}
+    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- end }}
+    {{- end }}
   wildcardPolicy: None
 {{- end }}
 {{- end }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
@@ -30,11 +30,11 @@ spec:
     {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
     {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
     {{- if $secret }}
-    {{- if index $secret.data "ca.crt" }}
+    {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
     {{- else }}
     {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-fileproxy-prod/templates/route.yaml
@@ -32,7 +32,7 @@ spec:
     {{- if $secret }}
     {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 6 }}
     {{- else }}
     {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
@@ -33,10 +33,10 @@ spec:
     destinationCACertificate: |
 {{ index $secret.data "ca.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
     {{- end }}
     {{- else }}
-    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
     {{- end }}
     {{- end }}
   wildcardPolicy: None
@@ -79,10 +79,10 @@ spec:
     destinationCACertificate: |
 {{ index $secret.data "ca.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
     {{- end }}
     {{- else }}
-    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
     {{- end }}
     {{- end }}
   wildcardPolicy: None

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
@@ -29,11 +29,11 @@ spec:
     {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
     {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
     {{- if $secret }}
-    {{- if index $secret.data "ca.crt" }}
+    {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
     {{- else }}
     {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}
@@ -75,11 +75,11 @@ spec:
     {{- if eq ($root.Values.global.routeType | upper) "REENCRYPT" }}
     {{- $secret := lookup "v1" "Secret" $root.Release.Namespace "ca-key-pair" }}
     {{- if $secret }}
-    {{- if index $secret.data "ca.crt" }}
+    {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
     {{- else }}
-    {{- fail "Secret ca-key-pair exists but does not contain the ca.crt key" }}
+    {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
     {{- else }}
     {{- fail "reencrypt mode enabled but secret ca-key-pair does not exist in the namespace" }}

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
@@ -26,6 +26,19 @@ spec:
   tls:
     termination: {{ .Values.global.routeType | default "passthrough" }}
     insecureEdgeTerminationPolicy: None
+    {{- if eq (.Values.global.routeType | upper) "REENCRYPT" }}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace "ca-key-pair" }}
+    {{- if $secret }}
+    {{- if index $secret.data "ca.crt" }}
+    destinationCACertificate: |
+{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+    {{- else }}
+    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- end }}
+    {{- else }}
+    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- end }}
+    {{- end }}
   wildcardPolicy: None
 status:
   ingress:
@@ -57,8 +70,21 @@ spec:
   port:
     targetPort: server-ssl-eif
   tls:
-    termination: {{ .Values.global.routeType | default "passthrough" }}
+    termination: {{ $root.Values.global.routeType | default "passthrough" }}
     insecureEdgeTerminationPolicy: None
+    {{- if eq ($root.Values.global.routeType | upper) "REENCRYPT" }}
+    {{- $secret := lookup "v1" "Secret" $root.Release.Namespace "ca-key-pair" }}
+    {{- if $secret }}
+    {{- if index $secret.data "ca.crt" }}
+    destinationCACertificate: |
+{{ index $secret.data "ca.crt" | b64dec | indent 4 }}
+    {{- else }}
+    {{- fail "Secret ca-key-pair existe mais ne contient pas la clé ca.crt" }}
+    {{- end }}
+    {{- else }}
+    {{- fail "Mode reencrypt activé mais secret ca-key-pair n'existe pas dans le namespace" }}
+    {{- end }}
+    {{- end }}
   wildcardPolicy: None
 status:
   ingress:

--- a/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
+++ b/helm_charts/ibm-workload-automation-prod/charts/wa-server-prod/templates/mdm-route.yaml
@@ -31,7 +31,7 @@ spec:
     {{- if $secret }}
     {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 6 }}
     {{- else }}
     {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}
@@ -77,7 +77,7 @@ spec:
     {{- if $secret }}
     {{- if index $secret.data "tls.crt" }}
     destinationCACertificate: |
-{{ index $secret.data "tls.crt" | b64dec | indent 4 }}
+{{ index $secret.data "tls.crt" | b64dec | indent 6 }}
     {{- else }}
     {{- fail "Secret ca-key-pair exists but does not contain the tls.crt key" }}
     {{- end }}


### PR DESCRIPTION
Problem:
OpenShift Routes configured with termination: reencrypt require spec.tls.destinationCACertificate so the router can validate the backend TLS certificate. Without it, the HAProxy router cannot verify the pod certificate and returns HTTP 503 for all traffic.

The Helm chart already generates a CA keypair at install time (ca-key-pair Secret) and uses it to sign backend TLS certificates. The destinationCACertificate field should therefore be populated from this same CA so reencrypt works end-to-end.

This is especially relevant when traffic comes through an external load balancer with an enterprise-signed certificate: the LB terminates the enterprise certificate, OpenShift re-encrypts to the pod using the chart-generated CA, and that second hop fails without destinationCACertificate.

Solution:
Conditionally inject destinationCACertificate in route templates when global.routeType is reencrypt, sourcing it at render time via Helm lookup from ca-key-pair (tls.crt).

Impact:
- No duplication needed in values.yaml
- CA rotation is automatically picked up on next helm upgrade
- No behavior change for passthrough or edge routes

Testing:
Validated with helm upgrade --install on OpenShift using global.routeType: reencrypt. Routes are admitted and backend TLS validation succeeds.

Compatibility:
Requires ca-key-pair Secret in namespace (already created by existing chart install logic).
 
For offline helm template rendering (no live cluster), lookup does not resolve and destinationCACertificate is omitted; this is expected Helm behavior.